### PR TITLE
Fix testcase.getchildren() to use list() instead

### DIFF
--- a/vjunit/vjunit.py
+++ b/vjunit/vjunit.py
@@ -29,7 +29,7 @@ class VJunit(object):
             _testsuite["summary"] = testsuite.attrib
             for testcase in testsuite.iter(tag="testcase"):
                 _testcase = testcase.attrib
-                children = testcase.getchildren()
+                children = list(testcase)
                 if children:
                     stdout = []
                     for child in children:


### PR DESCRIPTION
Since the new version 3.11.1 (released on December 15, 2022) of python 3.9, the getchildren() and getiterator() methods of classes have been removed.

The recommendation is to use iter(x) or list(x) instead of x.getchildren().

https://docs.python.org/3/whatsnew/3.9.html

Related to this issue: #5 